### PR TITLE
test: add date.timezone INI directive

### DIFF
--- a/ext/tests/availability.phpt
+++ b/ext/tests/availability.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Check for COLOPL PHP Backward Compatibility Extension availability.
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 echo extension_loaded('colopl_bc')

--- a/ext/tests/php70/array_rand.phpt
+++ b/ext/tests/php70/array_rand.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\array_rand() function compatibility.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS !== 0) print 'skip ZTS not supported'; 

--- a/ext/tests/php70/array_rand_zts.phpt
+++ b/ext/tests/php70/array_rand_zts.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\array_rand() function compatibility. (ZTS)
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS === 0) print 'skip NTS not supported';

--- a/ext/tests/php70/date_create.phpt
+++ b/ext/tests/php70/date_create.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\date_create() function.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 

--- a/ext/tests/php70/date_create_immutable.phpt
+++ b/ext/tests/php70/date_create_immutable.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\date_create_immutable() function.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 

--- a/ext/tests/php70/mt_rand_atomic.phpt
+++ b/ext/tests/php70/mt_rand_atomic.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\mt_srand() function atomically.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php 
 if (PHP_INT_SIZE !== 8) die("skip this test is for 64bit platform only");

--- a/ext/tests/php70/mt_rand_compatibility.phpt
+++ b/ext/tests/php70/mt_rand_compatibility.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\mt_srand() function other environment compatibility.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE !== 8) die("skip this test is for 64bit platform only");

--- a/ext/tests/php70/mt_rand_incompatibility.phpt
+++ b/ext/tests/php70/mt_rand_incompatibility.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\mt_srand() function other environment incompatibility.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 

--- a/ext/tests/php70/rand_atomic.phpt
+++ b/ext/tests/php70/rand_atomic.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\srand() function atomically.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE !== 8) die("skip this test is for 64bit platform only");

--- a/ext/tests/php70/rand_compatibility.phpt
+++ b/ext/tests/php70/rand_compatibility.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php70\srand() and srand() function other environment compatibility.
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (!extension_loaded('colopl_bc')) print 'skip';

--- a/ext/tests/php70/rand_incompatibility.phpt
+++ b/ext/tests/php70/rand_incompatibility.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\srand() function other environment incompatibility.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 

--- a/ext/tests/php70/shuffle.phpt
+++ b/ext/tests/php70/shuffle.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\shuffle() function compatibility.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS !== 0) print 'skip ZTS not supported'; 

--- a/ext/tests/php70/shuffle_zts.phpt
+++ b/ext/tests/php70/shuffle_zts.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\shuffle() function compatibility. (ZTS)
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS === 0) print 'skip NTS not supported'; 

--- a/ext/tests/php70/str_shuffle.phpt
+++ b/ext/tests/php70/str_shuffle.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\str_shuffle() function compatibility.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS !== 0) print 'skip ZTS not supported'; 

--- a/ext/tests/php70/str_shuffle_zts.phpt
+++ b/ext/tests/php70/str_shuffle_zts.phpt
@@ -2,6 +2,8 @@
 Check for \Colopl\ColoplBc\Php70\str_shuffle() function compatibility. (ZTS)
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS === 0) print 'skip NTS not supported'; 

--- a/ext/tests/php70/undefined_behavior_compatibility.phpt
+++ b/ext/tests/php70/undefined_behavior_compatibility.phpt
@@ -2,6 +2,8 @@
 Check undefined behavior compatibility (compatible for amd64)
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --SKIPIF--
 <?php
 if (PHP_ZTS !== 0) print 'skip ZTS not supported'; 

--- a/ext/tests/php74/binaryop/compare_001.phpt
+++ b/ext/tests/php74/binaryop/compare_001.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\eq() function. (Upstream: comparing different v
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_001_64bit.phpt
+++ b/ext/tests/php74/binaryop/compare_001_64bit.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\eq() function. (Upstream: comparing different v
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_003.phpt
+++ b/ext/tests/php74/binaryop/compare_003.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\gt() function. (Upstream: comparing different v
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_003_64bit.phpt
+++ b/ext/tests/php74/binaryop/compare_003_64bit.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\gt() function. (Upstream: comparing different v
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_004.phpt
+++ b/ext/tests/php74/binaryop/compare_004.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\lt() function. (Upstream: comparing different v
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_004_64bit.phpt
+++ b/ext/tests/php74/binaryop/compare_004_64bit.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\lt() function. (Upstream: comparing different v
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_005.phpt
+++ b/ext/tests/php74/binaryop/compare_005.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\gte() function. (Upstream: comparing different 
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_005_64bit.phpt
+++ b/ext/tests/php74/binaryop/compare_005_64bit.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\gte() function. (Upstream: comparing different 
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_006.phpt
+++ b/ext/tests/php74/binaryop/compare_006.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\lte() function. (Upstream: comparing different 
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/binaryop/compare_006_64bit.phpt
+++ b/ext/tests/php74/binaryop/compare_006_64bit.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\lte() function. (Upstream: comparing different 
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/compare_mode_change.phpt
+++ b/ext/tests/php74/compare_mode_change.phpt
@@ -3,6 +3,7 @@ Check for colopl_bc.php74.compare_mode change runtime
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 --FILE--
 <?php

--- a/ext/tests/php74/function/array_keys.phpt
+++ b/ext/tests/php74/function/array_keys.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\array_keys() function. (colopl_bc.php74.compare_mode=3)
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/array_multisort.phpt
+++ b/ext/tests/php74/function/array_multisort.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\array_multisort() function. (colopl_bc.php74.compare_mode=3)
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/array_search.phpt
+++ b/ext/tests/php74/function/array_search.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\array_search() function. (colopl_bc.php74.compare_mode=3)
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/arsort.phpt
+++ b/ext/tests/php74/function/arsort.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\arsort() function. (colopl_bc.php74.compare_mode=3)
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/asort.phpt
+++ b/ext/tests/php74/function/asort.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\asort() function. (colopl_bc.php74.compare_mode=3)
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/in_array.phpt
+++ b/ext/tests/php74/function/in_array.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\in_array() function. (colopl_bc.php74.compare_mode=3)
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/krsort.phpt
+++ b/ext/tests/php74/function/krsort.phpt
@@ -1,11 +1,12 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\krsort() function. (colopl_bc.php74.compare_mode=3)
+--EXTENSIONS--
+colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3
---EXTENSIONS--
-colopl_bc
 --FILE--
 <?php
 $array = ['a' => 1, '0' => 1, '' => 1, 'b' => 1, 'c' => 1, 'd' => 1, 'e' => 1, 'f' => 1, 'g' => 1, 'h' => 1, 'i' => 1, 'j' => 1, 'k' => 1, 'l' => 1, 'm' => 1, 'o' => 1, 'p' => 1, 'q' => 1, 'r' => 1, 's' => 1, 't' => 1, 'u' => 1, 'v' => 1, 'w' => 1, 'x' => 1, 'y' => 1, 'z' => 1];

--- a/ext/tests/php74/function/krsort_php82later.phpt
+++ b/ext/tests/php74/function/krsort_php82later.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\krsort() function. PHP >= 8.2 (colopl_bc.php74.
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/ksort.phpt
+++ b/ext/tests/php74/function/ksort.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\ksort() function. (colopl_bc.php74.compare_mode
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/ksort_php82later.phpt
+++ b/ext/tests/php74/function/ksort_php82later.phpt
@@ -3,6 +3,7 @@ Check for \Colopl\ColoplBc\Php74\ksort() function. PHP >= 8.2 (colopl_bc.php74.c
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3

--- a/ext/tests/php74/function/rsort.phpt
+++ b/ext/tests/php74/function/rsort.phpt
@@ -1,11 +1,12 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\rsort() function. (colopl_bc.php74.compare_mode=3)
+--EXTENSIONS--
+colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3
---EXTENSIONS--
-colopl_bc
 --FILE--
 <?php
 $array = ['0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, ''];

--- a/ext/tests/php74/function/sort.phpt
+++ b/ext/tests/php74/function/sort.phpt
@@ -1,11 +1,12 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\sort() function. (colopl_bc.php74.compare_mode=3)
+--EXTENSIONS--
+colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3
---EXTENSIONS--
-colopl_bc
 --FILE--
 <?php
 $array = ['0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, '', '0', 0, ''];

--- a/ext/tests/php74/function/uasort.phpt
+++ b/ext/tests/php74/function/uasort.phpt
@@ -1,11 +1,12 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\uasort() function. (colopl_bc.php74.compare_mode=3)
+--EXTENSIONS--
+colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3
---EXTENSIONS--
-colopl_bc
 --FILE--
 <?php
 $array = range(1, 64);

--- a/ext/tests/php74/function/uksort.phpt
+++ b/ext/tests/php74/function/uksort.phpt
@@ -1,11 +1,12 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\uksort() function. (colopl_bc.php74.compare_mode=3)
+--EXTENSIONS--
+colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3
---EXTENSIONS--
-colopl_bc
 --FILE--
 <?php
 $array = range(1, 64);

--- a/ext/tests/php74/function/usort.phpt
+++ b/ext/tests/php74/function/usort.phpt
@@ -1,11 +1,12 @@
 --TEST--
 Check for \Colopl\ColoplBc\Php74\usort() function. (colopl_bc.php74.compare_mode=3)
+--EXTENSIONS--
+colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 colopl_bc.php74.compare_mode=3
 colopl_bc.php74.sort_mode=3
---EXTENSIONS--
-colopl_bc
 --FILE--
 <?php
 $array = range(1, 64);

--- a/ext/tests/php74/sort_mode_change.phpt
+++ b/ext/tests/php74/sort_mode_change.phpt
@@ -3,6 +3,7 @@ Check for colopl_bc.php74.sort_mode change runtime
 --EXTENSIONS--
 colopl_bc
 --INI--
+date.timezone=UTC
 error_log=
 --FILE--
 <?php

--- a/ext/tests/reflection.phpt
+++ b/ext/tests/reflection.phpt
@@ -2,6 +2,8 @@
 Check for colopl_bc functions reflection information.
 --EXTENSIONS--
 colopl_bc
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 foreach ((new ReflectionExtension('colopl_bc'))->getFunctions() as $function) { echo $function; }


### PR DESCRIPTION
The current test will fail if the timezone is not properly set in the INI. Adding an INI directive will work around this.

![image](https://github.com/colopl/php-colopl_bc/assets/10289597/1afa9980-2d49-48fa-9acd-7986784d5c66)
