### PR TITLE
fix: avoid header pollution from Mersenne Twister helper macros

### DIFF
--- a/ext/colopl_bc_php70.c
+++ b/ext/colopl_bc_php70.c
@@ -142,6 +142,15 @@ PHP_FUNCTION(Colopl_ColoplBc_Php70_getrandmax)
 
 /* mt_rand.c */
 
+#define N				COLOPL_BC_MT_N			/* length of state vector */
+#define M				(397)					/* a period parameter */
+#define hiBit(u)		((u) & 0x80000000U)		/* mask all but highest   bit of u */
+#define loBit(u)		((u) & 0x00000001U)		/* mask all but lowest    bit of u */
+#define loBits(u)		((u) & 0x7FFFFFFFU)		/* mask     the highest   bit of u */
+#define mixBits(u, v)	(hiBit(u)|loBits(v))	/* move hi bit of u to hi bit of v */
+
+#define twist(m,u,v)	(m ^ (mixBits(u,v)>>1) ^ ((uint32_t)(-(uint32_t)(loBit(u))) & 0x9908b0dfU))
+
 static inline void mt_initialize(uint32_t seed, uint32_t *state)
 {
 	register uint32_t *s = state;

--- a/ext/php_colopl_bc.h
+++ b/ext/php_colopl_bc.h
@@ -48,7 +48,7 @@ ZEND_BEGIN_MODULE_GLOBALS(colopl_bc)
 	bool rand_is_seeded;
 	bool mt_rand_is_seeded;
 	uint32_t rand_seed;
-	uint32_t mt_state[N+1];
+	uint32_t mt_state[COLOPL_BC_MT_N+1];
 	uint32_t *mt_next;
 	int mt_left;
 	int gnurandom_r[344];

--- a/ext/php_colopl_bc_php70.h
+++ b/ext/php_colopl_bc_php70.h
@@ -113,14 +113,7 @@ PHPAPI zend_long php_colopl_bc_rand(void);
 
 #define PHP_COLOPL_BC_MT_RAND_MAX ((zend_long) (0x7FFFFFFF)) /* (1<<31) - 1 */
 
-#define N				(624)					/* length of state vector */
-#define M				(397)					/* a period parameter */
-#define hiBit(u)		((u) & 0x80000000U)		/* mask all but highest   bit of u */
-#define loBit(u)		((u) & 0x00000001U)		/* mask all but lowest    bit of u */
-#define loBits(u)		((u) & 0x7FFFFFFFU)		/* mask     the highest   bit of u */
-#define mixBits(u, v)	(hiBit(u)|loBits(v))	/* move hi bit of u to hi bit of v */
-
-#define twist(m,u,v)	(m ^ (mixBits(u,v)>>1) ^ ((uint32_t)(-(uint32_t)(loBit(u))) & 0x9908b0dfU))
+#define COLOPL_BC_MT_N	(624)
 
 PHPAPI void php_colopl_bc_mt_srand(uint32_t seed);
 PHPAPI uint32_t php_colopl_bc_mt_rand(void);


### PR DESCRIPTION
## Summary

`ext/php_colopl_bc_php70.h` defined unprefixed Mersenne Twister macros
(`N`, `M`, `hiBit`, `loBit`, `loBits`, `mixBits`, `twist`) in a public
header. They leak into every TU that includes `php_colopl_bc.h`, and
when `colopl_bc` is statically linked into PHP alongside e.g. libsodium,
the bare `N` collides with other extensions' declarations.

The header-level collision has been a latent issue since the extension
was first imported, but it only became visible on **PHP 8.4+** after
[php/php-src#14515](https://github.com/php/php-src/pull/14515)
([aae237aad5](https://github.com/php/php-src/commit/aae237aad5)) added
`#include <sodium.h>` to `ext/sodium/php_libsodium.h`. That pulled
libsodium's full API — including scrypt's `uint64_t N, uint32_t r, ...`
declaration — into `internal_functions_cli.c` during static builds.

## Error example

```
/usr/src/php/ext/colopl_bc/php_colopl_bc_php70.h:116:42:
  error: expected ')' before numeric constant
  116 | #define N                               (624)
/usr/include/sodium/crypto_pwhash_scryptsalsa208sha256.h:106:55:
  error: expected ';', ',' or ')' before 'uint32_t'
  106 | uint64_t N, uint32_t r, uint32_t p,
```

Reproduced on PHP 8.5.5 with `--enable-colopl_bc --with-sodium` (static
build). Shared builds (`--enable-colopl_bc=shared`) and PHP <= 8.3 are
unaffected.

## Fix

- Expose only the state-vector length as `COLOPL_BC_MT_N` in the header
  (required by the module-globals struct).
- Move the remaining MT helpers to `ext/colopl_bc_php70.c` as
  implementation details.
- Inside the .c file, keep upstream short names (`N`, `M`, `twist`, ...)
  via `#define N COLOPL_BC_MT_N`, matching php-src's historical
  `ext/standard/mt_rand.c` style.

## Test plan

- [x] `make test` passes (37 passed / 0 failed; 9 skipped are ZTS-only)
- [x] `tests/php70/mt_rand_compatibility.phpt` — bit-exact MT output
      unchanged
- [x] PHP 8.5.5 static build with `--with-sodium` reproduces the failure
      on `main` and succeeds on this branch (verified in a clean
      `php:8.5-cli-trixie` Docker container; resulting binary loads both
      `colopl_bc` and `sodium`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)